### PR TITLE
fix: Remove Cosmos wallet connect from navigation menu

### DIFF
--- a/apps/flame-defi/app/components/navigation-menu/connect-wallets-button.tsx
+++ b/apps/flame-defi/app/components/navigation-menu/connect-wallets-button.tsx
@@ -8,17 +8,13 @@ import { FlameIcon } from "@repo/ui/icons/polychrome";
 import { shortenAddress } from "@repo/ui/utils";
 import { ConnectWalletContent } from "components/connect-wallet";
 import { useEvmChainData } from "config";
-import { useCosmosWallet } from "features/cosmos-wallet";
 import { useEvmWallet } from "features/evm-wallet";
-import { usePathname } from "next/navigation";
 import { useAccount } from "wagmi";
 
 /**
  * Button with dropdown to connect to multiple wallets.
  */
 export const ConnectWalletsButton = () => {
-  const pathname = usePathname();
-  const { cosmosAccountAddress } = useCosmosWallet();
   const { selectedChain } = useEvmChainData();
   const account = useAccount();
   const {

--- a/apps/flame-defi/app/components/navigation-menu/mobile-navigation-menu.tsx
+++ b/apps/flame-defi/app/components/navigation-menu/mobile-navigation-menu.tsx
@@ -21,7 +21,6 @@ import { cn, shortenAddress } from "@repo/ui/utils";
 import { ConnectWalletContent } from "components/connect-wallet";
 import { LINKS } from "components/footer/links";
 import { useConfig, useEvmChainData } from "config";
-import { useCosmosWallet } from "features/cosmos-wallet";
 import { useEvmWallet } from "features/evm-wallet";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
@@ -33,7 +32,6 @@ import { NetworkIcon } from "./network-icon";
 export const MobileNavigationMenu = () => {
   const pathname = usePathname();
   const account = useAccount();
-  const { cosmosAccountAddress } = useCosmosWallet();
   const {
     featureFlags,
     networksList,


### PR DESCRIPTION
- Remove Cosmos wallet connect from navigation menu. As discussed, Cosmos wallet connection is specific to the bridge page, so we'll keep the logic in that context.
- I made some shared components in #191 when we had to handle both EVM and Cosmos wallet connection, but I think we can remove these now. Will keep them until the bridge page refactor is complete, since they're used by `ConnectCosmosWalletButton` and `ConnectEvmWalletButton`.