### PR TITLE
fix(pool): Disable creating a position

### DIFF
--- a/apps/flame-defi/app/pool/modules/create-position/components/submit-button/submit-button.tsx
+++ b/apps/flame-defi/app/pool/modules/create-position/components/submit-button/submit-button.tsx
@@ -426,16 +426,19 @@ export const SubmitButton = ({
   }, [state, token0?.coinDenom, token1?.coinDenom]);
 
   const isDisabled = useMemo(() => {
-    return (
-      isPendingToken0Allowance ||
-      isPendingToken1Allowance ||
-      [
-        ButtonState.INSUFFICIENT_BALANCE,
-        ButtonState.PENDING_SEND_TRANSACTION,
-        ButtonState.INVALID_INPUT,
-      ].includes(state)
-    );
-  }, [isPendingToken0Allowance, isPendingToken1Allowance, state]);
+    // Disable creating a position for EOL.
+    return true;
+
+    // return (
+    //   isPendingToken0Allowance ||
+    //   isPendingToken1Allowance ||
+    //   [
+    //     ButtonState.INSUFFICIENT_BALANCE,
+    //     ButtonState.PENDING_SEND_TRANSACTION,
+    //     ButtonState.INVALID_INPUT,
+    //   ].includes(state)
+    // );
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
Resolves [#53](https://github.com/astriaorg/internal-planning/issues/53).

## Summary
• Disables position creation functionality in the pool module for EOL (End of Life)
• Modifies submit button to always return disabled state instead of checking balance/allowance conditions
• Keep existing logic for easy reversion if we want to enable in the future

## Test plan
- [x] Verify that the create position submit button is disabled
- [x] Confirm existing positions are not affected
- [x] Test that other pool functionality remains working

🤖 Generated with [Claude Code](https://claude.ai/code)