### PR TITLE
fix(bridge): Improve manual address input design

### DIFF
--- a/apps/flame-defi/app/bridge/modules/deposit/sections/content-section.tsx
+++ b/apps/flame-defi/app/bridge/modules/deposit/sections/content-section.tsx
@@ -13,6 +13,7 @@ import {
   Card,
   CardContent,
   Input,
+  Skeleton,
 } from "@repo/ui/components";
 import { ArrowDownIcon, EditIcon, WalletIcon } from "@repo/ui/icons";
 import { shortenAddress } from "@repo/ui/utils";
@@ -348,20 +349,23 @@ export const ContentSection = () => {
               {/* Source wallet info - unified display regardless of chain type */}
               {sourceConnection.address && (
                 <Card variant="secondary" className="mt-3 p-6">
-                  <p className="text-typography-light font-medium">
+                  <p className="text-sm text-typography-light">
                     Address: {shortenAddress(sourceConnection.address)}
                   </p>
                   {sourceConnection.currency &&
                     sourceConnection.isConnected && (
-                      <p className="mt-2 text-typography-subdued font-medium">
-                        Balance: {isLoadingSourceBalance && "Loading..."}
+                      <div className="flex mt-2 text-sm text-typography-subdued">
+                        Balance:&nbsp;
+                        {isLoadingSourceBalance && (
+                          <Skeleton className="w-32 h-5" />
+                        )}
                         {!isLoadingSourceBalance &&
                           sourceBalance &&
                           `${sourceBalance.value} ${sourceBalance.symbol}`}
                         {!isLoadingSourceBalance &&
                           !sourceBalance &&
                           `0 ${sourceConnection.currency.coinDenom}`}
-                      </p>
+                      </div>
                     )}
                   {sourceConnection.currency &&
                     sourceConnection.currency instanceof EvmCurrency &&
@@ -431,26 +435,29 @@ export const ContentSection = () => {
                     className="mt-3 p-6 border border-transparent hover:border-stroke-default"
                   >
                     <p
-                      className="text-typography-light font-medium cursor-pointer"
+                      className="flex items-center text-sm text-typography-light cursor-pointer"
                       onKeyDown={handleEditRecipientClick}
                       onClick={handleEditRecipientClick}
                     >
                       <span className="mr-2">
                         Address: {shortenAddress(destinationConnection.address)}
                       </span>
-                      <i className="fas fa-pen-to-square" />
+                      <EditIcon className="inline-block ml-1" size={16} />
                     </p>
                     {destinationConnection.currency &&
                       destinationConnection.isConnected && (
-                        <p className="mt-2 text-typography-subdued font-medium">
-                          Balance: {isLoadingDestinationBalance && "Loading..."}
+                        <div className="flex mt-2 text-sm text-typography-subdued">
+                          Balance:&nbsp;
+                          {isLoadingDestinationBalance && (
+                            <Skeleton className="w-32 h-5" />
+                          )}
                           {!isLoadingDestinationBalance &&
                             destinationBalance &&
                             `${destinationBalance.value} ${destinationBalance.symbol}`}
                           {!isLoadingDestinationBalance &&
                             !destinationBalance &&
                             `0 ${destinationConnection.currency.coinDenom}`}
-                        </p>
+                        </div>
                       )}
                     {destinationCurrencyOption?.value &&
                       destinationCurrencyOption.value instanceof EvmCurrency &&
@@ -473,14 +480,14 @@ export const ContentSection = () => {
                   className="mt-3 p-6 border border-transparent hover:border-stroke-default"
                 >
                   <p
-                    className="text-typography-light font-medium cursor-pointer"
+                    className="flex items-center text-sm text-typography-light cursor-pointer"
                     onKeyDown={handleEditRecipientClick}
                     onClick={handleEditRecipientClick}
                   >
                     <span className="mr-2">
                       Address: {shortenAddress(recipientAddressOverride)}
                     </span>
-                    <i className="fas fa-pen-to-square" />
+                    <EditIcon className="inline-block ml-1" size={16} />
                   </p>
                   {!isRecipientAddressValid && hasTouchedForm && (
                     <div className="text-xs text-danger mt-2">
@@ -489,7 +496,7 @@ export const ContentSection = () => {
                   )}
                   {destinationConnection.currency && (
                     <p className="mt-2 text-typography-subdued text-xs">
-                      Connect via wallet to show balance.
+                      Connect wallet to show balance.
                     </p>
                   )}
                 </Card>
@@ -505,12 +512,17 @@ export const ContentSection = () => {
                       value={recipientAddressOverride}
                     />
                     <div className="mt-3 flex space-x-2">
-                      <Button size="sm" onClick={handleEditRecipientSave}>
+                      <Button
+                        size="sm"
+                        className="min-w-24"
+                        onClick={handleEditRecipientSave}
+                      >
                         Save
                       </Button>
                       <Button
                         size="sm"
                         variant="secondary"
+                        className="min-w-24"
                         onClick={handleEditRecipientClear}
                       >
                         Clear

--- a/apps/flame-defi/app/bridge/modules/withdraw/sections/content-section.tsx
+++ b/apps/flame-defi/app/bridge/modules/withdraw/sections/content-section.tsx
@@ -12,6 +12,7 @@ import {
   Card,
   CardContent,
   Input,
+  Skeleton,
 } from "@repo/ui/components";
 import { ArrowDownIcon, EditIcon, WalletIcon } from "@repo/ui/icons";
 import { shortenAddress } from "@repo/ui/utils";
@@ -349,20 +350,23 @@ export const ContentSection = () => {
               {/* Source wallet info */}
               {sourceConnection.address && (
                 <Card variant="secondary" className="mt-3 p-6">
-                  <p className="text-typography-light font-medium">
+                  <p className="text-sm text-typography-light">
                     Address: {shortenAddress(sourceConnection.address)}
                   </p>
                   {sourceConnection.currency &&
                     sourceConnection.isConnected && (
-                      <p className="mt-2 text-typography-subdued font-medium">
-                        Balance: {isLoadingSourceBalance && "Loading..."}
+                      <div className="flex mt-2 text-sm text-typography-subdued">
+                        Balance:&nbsp;
+                        {isLoadingSourceBalance && (
+                          <Skeleton className="w-32 h-5" />
+                        )}
                         {!isLoadingSourceBalance &&
                           sourceBalance &&
                           `${sourceBalance.value} ${sourceBalance.symbol}`}
                         {!isLoadingSourceBalance &&
                           !sourceBalance &&
                           `0 ${sourceConnection.currency.coinDenom}`}
-                      </p>
+                      </div>
                     )}
                   {sourceConnection.currency instanceof EvmCurrency &&
                     !isLoadingSourceBalance &&
@@ -428,25 +432,28 @@ export const ContentSection = () => {
                 !recipientAddressOverride && (
                   <Card variant="secondary" className="mt-3 p-6">
                     <p
-                      className="text-typography-light font-medium cursor-pointer"
+                      className="flex items-center text-sm text-typography-light cursor-pointer"
                       onClick={handleEditRecipientClick}
                     >
                       <span className="mr-2">
                         Address: {shortenAddress(destinationConnection.address)}
                       </span>
-                      <i className="fas fa-pen-to-square" />
+                      <EditIcon className="inline-block ml-1" size={16} />
                     </p>
                     {destinationConnection.currency &&
                       destinationConnection.isConnected && (
-                        <p className="mt-2 text-typography-subdued font-medium">
-                          Balance: {isLoadingDestinationBalance && "Loading..."}
+                        <div className="flex mt-2 text-sm text-typography-subdued">
+                          Balance:&nbsp;
+                          {isLoadingDestinationBalance && (
+                            <Skeleton className="w-32 h-5" />
+                          )}
                           {!isLoadingDestinationBalance &&
                             destinationBalance &&
                             `${destinationBalance.value} ${destinationBalance.symbol}`}
                           {!isLoadingDestinationBalance &&
                             !destinationBalance &&
                             `0 ${destinationConnection.currency.coinDenom}`}
-                        </p>
+                        </div>
                       )}
                   </Card>
                 )}
@@ -458,13 +465,13 @@ export const ContentSection = () => {
                   className="mt-3 p-6 border border-transparent hover:border-stroke-default"
                 >
                   <p
-                    className="text-typography-light font-medium cursor-pointer"
+                    className="flex items-center text-sm text-typography-light cursor-pointer"
                     onClick={handleEditRecipientClick}
                   >
                     <span className="mr-2">
                       Address: {shortenAddress(recipientAddressOverride)}
                     </span>
-                    <i className="fas fa-pen-to-square" />
+                    <EditIcon className="inline-block ml-1" size={16} />
                   </p>
                   {!isRecipientAddressValid && hasTouchedForm && (
                     <div className="mt-2 text-danger text-xs">
@@ -472,7 +479,7 @@ export const ContentSection = () => {
                     </div>
                   )}
                   <p className="mt-2 text-typography-subdued text-xs">
-                    Connect via wallet to show balance.
+                    Connect wallet to show balance.
                   </p>
                 </Card>
               )}
@@ -488,12 +495,17 @@ export const ContentSection = () => {
                       value={recipientAddressOverride}
                     />
                     <div className="mt-3 flex space-x-2">
-                      <Button size="sm" onClick={handleEditRecipientSave}>
+                      <Button
+                        size="sm"
+                        className="min-w-24"
+                        onClick={handleEditRecipientSave}
+                      >
                         Save
                       </Button>
                       <Button
                         size="sm"
                         variant="secondary"
+                        className="min-w-24"
                         onClick={handleEditRecipientClear}
                       >
                         Clear

--- a/apps/flame-defi/app/globals.css
+++ b/apps/flame-defi/app/globals.css
@@ -267,20 +267,15 @@
   @keyframes lightUpOrange {
     0% {
       opacity: 0.2;
-      box-shadow: none;
-      border-color: #f5f5f5;
+      border-color: var(--color-surface-2);
     }
     50% {
       opacity: 1;
-      box-shadow:
-        0 0 10px #df5822,
-        0 0 20px #f09226;
-      border-color: #f09226;
+      border-color: var(--color-orange);
     }
     100% {
       opacity: 0.2;
-      box-shadow: none;
-      border-color: #f5f5f5;
+      border-color: var(--color-surface-2);
     }
   }
 }

--- a/packages/ui/src/components/atoms/input.tsx
+++ b/packages/ui/src/components/atoms/input.tsx
@@ -7,7 +7,7 @@ export const inputVariants = cva("", {
   variants: {
     variant: {
       default:
-        "border border-stroke-default bg-surface-1 text-typography focus-visible:border-stroke-active focus-visible:bg-transparent",
+        "border border-stroke-default bg-surface-1 text-typography focus-visible:border-stroke-active focus-visible:bg-background-default",
     },
   },
   defaultVariants: {

--- a/packages/ui/src/components/molecules/card/card-figure-input.tsx
+++ b/packages/ui/src/components/molecules/card/card-figure-input.tsx
@@ -17,7 +17,7 @@ export const CardFigureInput = ({
       <TokenAmountInput
         placeholder={placeholder}
         className={cn(
-          "bg-transparent border-none outline-hidden rounded-none shadow-none text-5xl/12 h-12 p-0 font-dot text-typography-default placeholder:text-typography-light",
+          "bg-transparent border-none outline-hidden rounded-none shadow-none text-5xl/12 h-12 p-0 font-dot text-typography-default placeholder:text-typography-light focus-visible:bg-transparent",
           className,
         )}
         {...props}


### PR DESCRIPTION
## Summary
• Migrate manual address input components to use consistent Card design system components
• Replace FontAwesome icons with proper EditIcon components for better visual consistency
• Add skeleton loading states for balance displays instead of plain "Loading..." text
• Improve input focus states and button styling with minimum widths and consistent variants

## Test plan
- [x] Test manual address input functionality in both deposit and withdraw flows
- [x] Verify skeleton loading states appear correctly during balance loading
- [x] Check that edit icons and buttons have proper hover/focus states
- [x] Confirm consistent styling across light/dark themes

🤖 Generated with [Claude Code](https://claude.ai/code)